### PR TITLE
Temporary fix for HamerunTheBleederAI2 help calling

### DIFF
--- a/AC-Game/data/scripts/system/handlers/ai/AggressiveNpcAI2.java
+++ b/AC-Game/data/scripts/system/handlers/ai/AggressiveNpcAI2.java
@@ -81,6 +81,9 @@ public class AggressiveNpcAI2 extends GeneralNpcAI2 {
      */
     protected void callForHelp(int distance) {
         Creature firstTarget = getAggroList().getMostHated();
+        if (firstTarget == null) {
+            return;
+        }
         for (VisibleObject object : getKnownList().getKnownObjects().values()) {
             if (object instanceof Npc && isInRange(object, distance)) {
                 Npc npc = (Npc) object;


### PR DESCRIPTION
While fighting with Hamerun, I got this exception:
java.lang.NullPointerException: Creature must not be null
        at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:208) ~[guava-13.0.1.jar:na]
        at com.aionemu.gameserver.ai2.AbstractAI.onCreatureEvent(AbstractAI.java:207) ~[AL-Game.jar:na]
        at ai.AggressiveNpcAI2.callForHelp(AggressiveNpcAI2.java]:88) ~[na:na]
        at ai.instance.haramel.HamerunTheBleederAI2.handleAttack(HamerunTheBleederAI2.java]:92) ~[na:na]
        at com.aionemu.gameserver.ai2.AbstractAI.handleCreatureEvent(AbstractAI.java:418) ~[AL-Game.jar:na]
        at com.aionemu.gameserver.ai2.AbstractAI.onCreatureEvent(AbstractAI.java:212) ~[AL-Game.jar:na]
        at com.aionemu.gameserver.controllers.attack.AggroList.addHateValue(AggroList.java:119) ~[AL-Game.jar:na]
        at com.aionemu.gameserver.controllers.attack.AggroList.addHate(AggroList.java:98) ~[AL-Game.jar:na]
        at com.aionemu.gameserver.skillengine.model.Effect.applyEffect(Effect.java:729) ~[AL-Game.jar:na]
        at com.aionemu.gameserver.skillengine.SkillEngine.applyEffectDirectly(SkillEngine.java:174) ~[AL-Game.jar:na]
        at com.aionemu.gameserver.skillengine.model.Skill.startPenaltySkill(Skill.java:516) ~[AL-Game.jar:na]
        at com.aionemu.gameserver.skillengine.model.Skill.applyEffect(Skill.java:767) ~[AL-Game.jar:na]
        at com.aionemu.gameserver.skillengine.model.Skill.endCast(Skill.java:735) ~[AL-Game.jar:na]
        at com.aionemu.gameserver.skillengine.model.Skill$2.run(Skill.java:815) ~[AL-Game.jar:na]
        at com.aionemu.commons.utils.concurrent.ExecuteWrapper.execute(ExecuteWrapper.java:56) ~[ac-commons-1.3.jar:na]
        at com.aionemu.commons.utils.concurrent.RunnableWrapper.run(RunnableWrapper.java:51) [ac-commons-1.3.jar:na]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471) [na:1.7.0_80]
        at java.util.concurrent.FutureTask.run(FutureTask.java:262) [na:1.7.0_80]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:178) [na:1.7.0_80]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:292) [na:1.7.0_80]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_80]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_80]
        at java.lang.Thread.run(Thread.java:745) [na:1.7.0_80]

It doesn't appear all the time. I am not sure why it happened, cause the called NPCs were summoned already. This quick fix should do the trick, but it's not ideal at all.